### PR TITLE
Dischargesummary

### DIFF
--- a/src/FHIRTemplate/AllergyIntolerance.cls
+++ b/src/FHIRTemplate/AllergyIntolerance.cls
@@ -1,0 +1,71 @@
+Class FHIRTemplate.AllergyIntolerance Extends FHIRTemplate.Resource
+{
+
+Parameter ResourceType = "AllergyIntolerance";
+
+Parameter ClinicalStatusCode = "active,inactive,resolved";
+
+Parameter ClinicalStatusDisplay = "現存,非現存,解消";
+
+Parameter VerificationStatusCode = "unconfirmed,confirmed,refuted,entered-in-error";
+
+Parameter VerificationStatusDisplay = "未確認,確認済,否定,エラー";
+
+Property TextDiv As %String(MAXLEN = 10000);
+
+/// identifier.value
+Property IdentifierValue As %String;
+
+Property ClinicalStatus As FHIRTemplate.Type.CodeableConcept;
+
+Property VerificationStatus As FHIRTemplate.Type.CodeableConcept;
+
+Property Type As %String(VALUELIST = ",allergy,intolerance");
+
+/// DISPLAYLIST = ",食物,医薬品,環境,生物学的"
+Property Category As %String(VALUELIST = ",food,medication,environment,biologic");
+
+/// DISPLAYLIST = ",低,高,評価不能",
+Property Criticality As %String(VALUELIST = ",low,high,unable-to-assess");
+
+Property Code As FHIRTemplate.Type.CodeableConcept;
+
+/// Patient のUUID
+Property Patient As %String;
+
+/// Encounter のUUID
+Property Encounter As %String;
+
+XData Template [ MimeType = application/json ]
+{
+{
+    "resourceType": "#(..#ResourceType)#",
+    "meta": {
+        "profile": ["http://jpfhir.jp/fhir/eClinicalSummary/StructureDefinition/JP_AllergyIntolerance_eClinicalSummary"]
+    },
+    "text":{
+        "status":"generated",
+        "div":"#(..TextDiv)#"
+    },
+    "identifier":[
+        {
+        "system":"http://jpfhir.jp/fhir/Common/CodeSystem/resourceInstance-identifier",
+        "value":"#(..IdentifierValue)#"
+        }
+    ],
+    "clinicalStatus": "#(..ClinicalStatus(FHIRTemplate.Type.CodeableConcept))#",
+    "verificationStatus":"#(..VerificationStatus(FHIRTemplate.Type.CodeableConcept))#",
+    "type":"#(..Type)#",
+    "category": ["#(..Category)#"],
+    "criticality":"#(..Criticality)#",
+    "code": "#(..Code(FHIRTemplate.Type.CodeableConcept))#",
+    "patient": {
+        "reference": "urn:uuid:#(..Patient)#"
+    },
+    "encounter":{
+        "reference":"urn:uuid:#(..Encounter)#"
+    }
+}
+}
+
+}

--- a/src/FHIRTemplate/BundleDischargeSummary.cls
+++ b/src/FHIRTemplate/BundleDischargeSummary.cls
@@ -1,0 +1,78 @@
+/// 退院時サマリ用Bundle
+Class FHIRTemplate.BundleDischargeSummary Extends FHIRTemplate.Resource
+{
+
+/// JSON出力する際のテンプレート
+XData Template [ MimeType = application/json ]
+{
+{
+  "resourceType": "#(..#ResourceType)#",
+  "meta": {
+    "profile": [
+      "#(..#Profile)#"
+    ]
+  },
+  "type": "document",
+  "timestamp": "#(..TimeStamp)#",
+  "entry": [
+    "#(..Composition(FHIRTemplate.Bundle.entry))#",
+    "#(..Patient(FHIRTemplate.Bundle.entry))#",
+    "#(..Practitioner(FHIRTemplate.Bundle.entry))#",
+    "#(..Organization(FHIRTemplate.Bundle.entry))#",
+    "#(..Encounter(FHIRTemplate.Bundle.entry))#",
+    "#(..Condition(FHIRTemplate.Bundle.entry))#",
+    "#(..AllergyIntolerance(FHIRTemplate.Bundle.entry))#",
+    "#(..MedicationRequest(FHIRTemplate.Bundle.entry))#",
+    "#(..CarePlan(FHIRTemplate.Bundle.entry))#",
+    "#(..DocumentReference(FHIRTemplate.Bundle.entry))#"
+  ],
+  "signature":{
+    "type":[
+      {
+      "system":"urn:iso-astm:E1762-95:2013",
+      "code":"1.2.840.10065.1.12.1.1"
+      }
+    ],
+    "when":"#(..When)#",
+    "who":{
+      "reference":"urn:uuid:#(..PractitionerResourceId)#"
+    },
+    "data":"6aOv5bO2576O56mC5a2Q"
+  }
+  }
+}
+
+Parameter ResourceType = "Bundle";
+
+Parameter Profile = "jpfhir.jp/fhir/eDischargeSummary/StructureDefinition/JP_Bundle_eDischargeSummary";
+
+Property TimeStamp As FHIRTemplate.Type.TimeStamp;
+
+Property Composition As CompositionDischargeSummary [ Required ];
+
+Property Patient As Patient [ Required ];
+
+Property Encounter As FHIRTemplate.Encounter;
+
+Property Practitioner As FHIRTemplate.Practitioner;
+
+Property PractitionerResourceId As %String;
+
+/// Property Practitioner As list Of Practitioner;
+Property Organization As FHIRTemplate.Organization;
+
+Property Condition As FHIRTemplate.Condition;
+
+Property AllergyIntolerance As FHIRTemplate.AllergyIntolerance;
+
+Property DocumentReference As FHIRTemplate.DocumentReference;
+
+Property MedicationRequest As FHIRTemplate.MedicationRequest;
+
+Property CarePlan As FHIRTemplate.CarePlan;
+
+Property Type As FHIRTemplate.Type.Coding;
+
+Property When As FHIRTemplate.Type.TimeStamp;
+
+}

--- a/src/FHIRTemplate/CarePlan.cls
+++ b/src/FHIRTemplate/CarePlan.cls
@@ -1,0 +1,74 @@
+Class FHIRTemplate.CarePlan Extends Resource
+{
+
+Parameter ResourceType = "CarePlan";
+
+Parameter CategorySystem = "http://jpfhir.jp/fhir/CarePlan/CodeSystem/category";
+
+Parameter CategoryDisplay = "discharge-plan,hospital-plan";
+
+Property TextDiv As %String(MAXLEN = 10000);
+
+/// identifier.value
+Property IdentifierValue As %String;
+
+/// statusvDISPLAYLIST = ",案,有効,保留,取消,完了,エラー,不明"
+Property Status As %String(VALUELIST = ",draft,active,on-hold,revoked,completed,entered-in-error,unknown");
+
+/// intent DISPLAYLIST = ",提案,計画,指示,オプション",
+Property Intent As %String(VALUELIST = ",proposal,plan,order,option");
+
+Property Category As FHIRTemplate.Type.CodeableConcept;
+
+Property Description As %String(MAXLEN = 10000);
+
+/// Patient のUUID
+Property Patient As %String;
+
+/// EncounterのUUID
+Property Encounter As %String;
+
+/// PractitionerのUUID
+Property Practitioner As %String;
+
+Property Period As FHIRTemplate.Type.Period;
+
+Property CreationTime As FHIRTemplate.Type.TimeStamp;
+
+XData Template [ MimeType = application/json ]
+{
+{
+    "resourceType": "#(..#ResourceType)#",
+    "meta": {
+        "profile": ["http://jpfhir.jp/fhir/eClinicalSummary/StructureDefinition/JP_CarePlan_eClinicalSummary"]
+    },
+    "text": {
+        "status": "generated",
+        "div": "#(..TextDiv)#"
+    },
+    "identifier": [
+        {
+            "system":"http://jpfhir.jp/fhir/Common/CodeSystem/resourceInstance-identifier",
+            "value": "#(..IdentifierValue)#"
+        }
+    ],    
+    "status": "#(..Status)#",
+    "intent": "#(..Intent)#",
+    "category": [ "#(..Category(FHIRTemplate.Type.CodeableConcept))#"],
+    "title":"退院時の方針",
+    "description":"#(..Description)#",
+    "subject": {
+        "reference": "urn:uuid:#(..Patient)#"
+    },
+    "encounter": {
+        "reference": "urn:uuid:#(..Encounter)#"
+    },
+    "period": "#(..Period)#",
+    "created":"#(..CreationTime)#",
+    "author":{
+        "reference":"urn:uuid:#(..Practitioner)#"
+    }
+}
+}
+
+}

--- a/src/FHIRTemplate/CompositionDischargeSummary.cls
+++ b/src/FHIRTemplate/CompositionDischargeSummary.cls
@@ -1,0 +1,373 @@
+Class FHIRTemplate.CompositionDischargeSummary Extends FHIRTemplate.Resource
+{
+
+XData Template [ MimeType = application/json ]
+{
+{
+  "resourceType": "#(..#ResourceType)#",
+  "meta": {
+    "profile": [
+      "#(..#Profile)#"
+    ]
+  },
+  "extension":[
+    {
+    "url":"http://hl7.org/fhir/StructureDefinition/composition-clinicaldocumentversionNumber",
+    "valueString":"#(..DocVersionNum)#"
+    }
+  ],
+  "identifier":{
+    "system":"http://jpfhir.jp/fhir/Common/CodeSystem/resourceInstanceidentifier",
+    "value":"#(..IdentifierValue)#"
+  },
+  "status":"final",
+  "type":{
+      "coding":[
+          {
+          "system":"http://jpfhir.jp/fhir/Common/CodeSystem/doc-typecodes",
+          "code":"18842-5",
+          "display":"退院時サマリー"
+          }
+      ]
+  },
+  "category":[
+      {
+        "coding":[
+            {
+            "system":"http://jpfhir.jp/fhir/eClinicalSummary/CodeSystem/eClinicalSummary-category",
+            "code":"18842-5",
+            "display":"退院時サマリー"
+            }
+        ]
+      }
+  ],
+  "subject":{
+    "reference":"urn:uuid:#(..Patient)#"
+  },
+  "encounter":{
+    "reference":"urn:uuid:#(..Encounter)#"
+  },
+  "date":"#(..CreationDate)#",
+  "author":[
+    {
+        "reference":"urn:uuid:#(..Practitioner)#"
+    },
+    {
+        "reference":"urn:uuid:#(..Organization)#"
+    }
+  ],
+  "title":"退院時サマリー",
+  "custodian":{
+    "reference":"urn:uuid:#(..Organization)#"
+  },
+  "section":[
+      {
+        "title":"構造情報",
+        "code":{
+          "coding":[
+            {
+            "system":"http://jpfhir.jp/fhir/eClinicalSummary/CodeSystem/document-section",
+            "code":"300",
+            "display":"構造情報"
+            }
+          ]
+        },
+        "text":{
+          "status":"additional",
+          "div":"#(..SectionText)#"
+        },
+        "section":[
+          {
+            "title":"入院詳細",
+            "code":{
+                "coding":[
+                    {
+                    "system":"http://jpfhir.jp/fhir/eClinicalSummary/CodeSystem/document-section",
+                    "code":"322",
+                    "display":"入院詳細"
+                    }
+                ]
+            },
+            "text":{
+                "status":"additional",
+                "div":"#(..SectionText322)#"
+            },
+            "entry":[
+                {
+                  "reference": "urn:uuid:#(..Encounter)#"
+                }
+            ]
+          },
+          {
+            "title":"入院時診断",
+            "code":{
+                "coding":[
+                    {
+                    "system":"http://jpfhir.jp/fhir/eClinicalSummary/CodeSystem/document-section",
+                    "code":"342",
+                    "display":"入院時診断"
+                    }
+                ]
+            },
+            "text":{
+                "status":"additional",
+                "div":"#(..SectionText342)#"
+            },
+            "entry":[
+                {
+                  "reference": "urn:uuid:#(..Condition)#"
+                }
+            ]
+          },
+          {
+            "title":"アレルギー・不耐性反応",
+            "code":{
+                "coding":[
+                    {
+                    "system":"http://jpfhir.jp/fhir/eClinicalSummary/CodeSystem/document-section",
+                    "code":"510",
+                    "display":"アレルギー・不耐性反応"
+                    }
+                ]
+            },
+            "text":{
+                "status":"additional",
+                "div":"#(..SectionText510)#"
+            },
+            "entry":[
+                {
+                    "reference": "urn:uuid:#(..AllergyIntolerance)#"
+                }
+            ]
+          },
+          {
+            "title":"入院時主訴",
+            "code":{
+                "coding":[
+                    {
+                    "system":"http://jpfhir.jp/fhir/eClinicalSummary/CodeSystem/document-section",
+                    "code":"352",
+                    "display":"入院時主訴"
+                    }
+                ]
+            },
+            "text":{
+                "status":"additional",
+                "div":"#(..SectionText352)#"
+            },
+            "entry":[
+                {
+                    "reference": "urn:uuid:#(..Condition)#"
+                }
+            ]
+          },
+          {
+            "title":"入院理由",
+            "code":{
+                "coding":[
+                    {
+                    "system":"http://jpfhir.jp/fhir/eClinicalSummary/CodeSystem/document-section",
+                    "code":"312",
+                    "display":"入院理由"
+                    }
+                ]
+            },
+            "text":{
+                "status":"additional",
+                "div":"#(..SectionText312)#"
+            },
+            "entry":[
+                {
+                    "reference": "urn:uuid:#(..Encounter)#"
+                }
+            ]
+          },
+          {
+            "title":"入院時現病歴",
+            "code":{
+                "coding":[
+                    {
+                    "system":"http://jpfhir.jp/fhir/eClinicalSummary/CodeSystem/document-section",
+                    "code":"362",
+                    "display":"入院時現病歴"
+                    }
+                ]
+            },
+            "text":{
+                "status":"additional",
+                "div":"#(..SectionText362)#"
+            },
+            "entry":[
+                {
+                    "reference": "urn:uuid:#(..Condition)#"
+                }
+            ]
+          },
+          {
+            "title":"入院中経過",
+            "code":{
+                "coding":[
+                    {
+                    "system":"http://jpfhir.jp/fhir/eClinicalSummary/CodeSystem/document-section",
+                    "code":"333",
+                    "display":"入院中経過"
+                    }
+                ]
+            },
+            "text":{
+                "status":"additional",
+                "div":"#(..SectionText333)#"
+            },
+            "entry":[
+                {
+                    "reference": "urn:uuid:#(..DocumentReference)#"
+                }
+            ]
+          },
+          {
+            "title":"退院時詳細",
+            "code":{
+                "coding":[
+                    {
+                    "system":"http://jpfhir.jp/fhir/eClinicalSummary/CodeSystem/document-section",
+                    "code":"324",
+                    "display":"退院時詳細"
+                    }
+                ]
+            },
+            "text":{
+                "status":"additional",
+                "div":"#(..SectionText324)#"
+            },
+            "entry":[
+                {
+                    "reference": "urn:uuid:#(..Encounter)#"
+                }
+            ]
+          },
+          {
+            "title":"退院時投薬指示",
+            "code":{
+                "coding":[
+                    {
+                    "system":"http://jpfhir.jp/fhir/eClinicalSummary/CodeSystem/document-section",
+                    "code":"444",
+                    "display":"退院時投薬指示"
+                    }
+                ]
+            },
+            "text":{
+                "status":"additional",
+                "div":"#(..SectionText444)#"
+            },
+            "entry":[
+                {
+                    "reference": "urn:uuid:#(..MedicationRequest)#"
+                }
+            ]
+          },
+          {
+          "title":"退院時方針指示",
+          "code":{
+              "coding":[
+                  {
+                  "system":"http://jpfhir.jp/fhir/eClinicalSummary/CodeSystem/document-section",
+                  "code":"424",
+                  "display":"退院時方針指示"
+                  }
+              ]
+          },
+          "text":{
+              "status":"additional",
+              "div":"#(..SectionText424)#"
+          },
+          "entry":[
+            {
+                "reference": "urn:uuid:#(..CarePlan)#"
+            }
+          ]
+        }
+        ]
+      }
+  ]
+}
+}
+
+Parameter ResourceType = "Composition";
+
+/// JSON出力する際のテンプレート
+/// JSONの値の文字列に#(..プロパティ名)#または#(..#パラメータ名)#を指定することで
+/// プロパティの値をJSON形式で出力できます。
+/// プロパティの型がJSONTemplate.Baseを継承したクラスの場合、
+/// そのクラスのテンプレートからJSON出力します。
+Parameter Profile = "http://jpfhir.jp/fhir/eDischargeSummary/StructureDefinition/JP_Composition_eDischargeSummary";
+
+Property DocVersionNum As %String;
+
+Property IdentifierValue As %String;
+
+/// PatientのUUID
+Property Patient As %String;
+
+/// EncounterのUUID
+Property Encounter As %String;
+
+Property CreationDate As FHIRTemplate.Type.TimeStamp;
+
+/// PractitionerのUUID
+Property Practitioner As %String;
+
+/// OrganizationのUUID
+Property Organization As %String;
+
+/// ConditionのUUID
+Property Condition As %String;
+
+/// AllergyIntoleranceのuuid
+Property AllergyIntolerance As %String;
+
+/// DocumentReferenceのUUID
+Property DocumentReference As %String;
+
+/// MedicationRequestのUUID
+Property MedicationRequest As %String;
+
+/// CarePlanのUUID
+Property CarePlan As %String;
+
+/// 構造情報のsection.text
+Property SectionText As %String(MAXLEN = 10000) [ InitialExpression = "<div xmlns='http://www.w3.org/1999/xhtml'>こんな状況でした</div>" ];
+
+/// 322入院詳細のsection.text
+Property SectionText322 As %String(MAXLEN = 10000) [ InitialExpression = "<div xmlns='http://www.w3.org/1999/xhtml'>入院詳細の状況</div>" ];
+
+/// 342入院時診断のsection.text
+Property SectionText342 As %String(MAXLEN = 10000) [ InitialExpression = "<div xmlns='http://www.w3.org/1999/xhtml'>入院時診断の状況</div>" ];
+
+/// 510アレルギー・不耐性反応のsection.text
+Property SectionText510 As %String(MAXLEN = 10000) [ InitialExpression = "<div xmlns='http://www.w3.org/1999/xhtml'>アレルギー・不耐性反応の状況</div>" ];
+
+/// 352入院時主訴のsection.text
+Property SectionText352 As %String(MAXLEN = 10000) [ InitialExpression = "<div xmlns='http://www.w3.org/1999/xhtml'>入院時主訴の状況</div>" ];
+
+/// 312入院理由のsection.text
+Property SectionText312 As %String(MAXLEN = 10000) [ InitialExpression = "<div xmlns='http://www.w3.org/1999/xhtml'>入院理由の状況</div>" ];
+
+/// 362入院時現病歴のsection.text
+Property SectionText362 As %String(MAXLEN = 10000) [ InitialExpression = "<div xmlns='http://www.w3.org/1999/xhtml'>入院時現病歴の状況</div>" ];
+
+/// 333入院中経過のsection.text
+Property SectionText333 As %String(MAXLEN = 10000) [ InitialExpression = "<div xmlns='http://www.w3.org/1999/xhtml'>入院中経過の状況</div>" ];
+
+/// 324退院時詳細のsection.text
+Property SectionText324 As %String(MAXLEN = 10000) [ InitialExpression = "<div xmlns='http://www.w3.org/1999/xhtml'>退院時詳細の状況</div>" ];
+
+/// 444退院時投薬指示のsection.text
+Property SectionText444 As %String(MAXLEN = 10000) [ InitialExpression = "<div xmlns='http://www.w3.org/1999/xhtml'>退院時投薬指示の状況</div>" ];
+
+/// 424退院時方針指示のsection.text
+Property SectionText424 As %String(MAXLEN = 10000) [ InitialExpression = "<div xmlns='http://www.w3.org/1999/xhtml'>退院時方針指示の状況</div>" ];
+
+Property Status As %Integer(DISPLAYLIST = ",preliminary,final,amended,entered-in-error", VALUELIST = ",0,1,-1,-2");
+
+}

--- a/src/FHIRTemplate/Condition.cls
+++ b/src/FHIRTemplate/Condition.cls
@@ -70,7 +70,7 @@ XData Template [ MimeType = application/json ]
     "bodySite": [ "#(..BodySite(FHIRTemplate.Type.CodeableConcept))#" ],
     "subject" : {
         "reference" : "urn:uuid:#(..Patient)#",
-        "display" : "urn:uuid:#(..PatientDisplayName)#"
+        "display" : "#(..PatientDisplayName)#"
     },
     "encounter":{
         "reference":"urn:uuid:#(..Encounter)#"

--- a/src/FHIRTemplate/Condition.cls
+++ b/src/FHIRTemplate/Condition.cls
@@ -1,0 +1,93 @@
+Class FHIRTemplate.Condition Extends Resource
+{
+
+Parameter ResourceType = "Condition";
+
+Parameter ClinicalStatusSystem = "http://hl7.org/fhir/ValueSet/condition-clinical";
+
+Parameter ClinicalStatusDisplay = "Lv0 active,Lv1 recurrence,Lv1 relapse,Lv0 inactive,Lv1 remission,Lv1 resolved";
+
+Parameter ClinicalStatusCode = "active,recurrence,relapse,inactive,remission,resolved";
+
+Parameter VerificationStatusSystem = "http://hl7.org/fhir/ValueSet/condition-ver-status";
+
+Parameter VerificationStatusCode = "unconfirmed,provisional,differential,confirmed,refuted,entered-in-error";
+
+Parameter VerificationStatusDisplay = "Lv0 unconfirmed,Lv1 provisional,Lv1 differential,Lv0 confirmed,Lv0 refuted,Lv0 entered-in-error";
+
+Property TextDiv As %String(MAXLEN = 10000);
+
+/// identifier.valueの値
+Property PatientStatusValue As %String;
+
+Property ClinicalStatus As FHIRTemplate.Type.CodeableConcept;
+
+Property VerificationStatus As FHIRTemplate.Type.CodeableConcept;
+
+Property Code As FHIRTemplate.Type.CodeableConcept;
+
+Property BodySite As FHIRTemplate.Type.CodeableConcept;
+
+/// Patientリソースのuuidを入れる
+Property Patient As %String;
+
+Property PatientDisplayName As %String;
+
+/// Encounterリソースのuuidを入れる
+Property Encounter As %String;
+
+Property Age As FHIRTemplate.Type.Age;
+
+Property RecordedDate As %String;
+
+Property EvidenceCode As FHIRTemplate.Type.CodeableConcept;
+
+/// リソースへのリファレンス
+Property EvidenceDetail As %String;
+
+/// 固定値
+/// meta.profile/
+XData Template [ MimeType = application/json ]
+{
+{
+    "resourceType" : "#(..#ResourceType)#",
+    "meta":{
+        "profile":["http://jpfhir.jp/fhir/eClinicalSummary/StructureDefinition/JP_Condition_eClinicalSummary"]
+    },
+    "text" : {
+        "status" : "generated",
+        "div" : "#(..TextDiv)#"
+    },
+    "identifier":[
+        {
+            "system":"http://jpfhir.jp/fhir/Common/CodeSystem/resourceInstance-identifier",
+            "value":"#(..PatientStatusValue)#"
+        }
+    ],
+    "clinicalStatus":"#(..ClinicalStatus(FHIRTemplate.Type.CodeableConcept))#",
+    "verificationStatus" : "#(..VerificationStatus(FHIRTemplate.Type.CodeableConcept))#",
+    "code": "#(..Code(FHIRTemplate.Type.CodeableConcept))#",
+    "bodySite": [ "#(..BodySite(FHIRTemplate.Type.CodeableConcept))#" ],
+    "subject" : {
+        "reference" : "urn:uuid:#(..Patient)#",
+        "display" : "urn:uuid:#(..PatientDisplayName)#"
+    },
+    "encounter":{
+        "reference":"urn:uuid:#(..Encounter)#"
+    },
+    "onsetAge": "#(..Age(FHIRTemplate.Type.Age))#",
+    "recordedDate": "#(..RecordedDate)#",
+    "evidence": [
+        {
+            "code": [ "#(..EvidenceCode(FHIRTemplate.Type.CodeableConcept))#"],
+            "detail":[
+                {
+                    "reference": "urn:uuid:#(..EvidenceDetail)#"
+                }
+            ]
+        }
+    ]
+}
+}
+
+}

--- a/src/FHIRTemplate/DocumentReference.cls
+++ b/src/FHIRTemplate/DocumentReference.cls
@@ -1,0 +1,34 @@
+Class FHIRTemplate.DocumentReference Extends FHIRTemplate.Resource
+{
+
+Parameter ResourceType = "DocumentReference";
+
+Property CreationTime As FHIRTemplate.Type.TimeStamp;
+
+Property PDFStream As %String(MAXLEN = 3000000);
+
+XData Template [ MimeType = application/json ]
+{
+{
+    "resource":{
+        "resourceType": "#(..#ResourceType)#",
+        "meta": {
+            "profile": ["http://jpfhir.jp/fhir/eClinicalSummary/StructureDefinition/JPDocumentReference_eClinicalSummary"]
+        },
+        "status":"current",
+        "description":"退院時サマリー",
+        "content":[
+            {
+                "attachment":{
+                    "creation":"#(..CreationTime)#",
+                    "contentType":"text/html",
+                    "data":"#(..PDFStream)#",
+                    "url":""
+                }
+            }
+        ]
+    }
+}
+}
+
+}

--- a/src/FHIRTemplate/Encounter.cls
+++ b/src/FHIRTemplate/Encounter.cls
@@ -1,0 +1,111 @@
+Class FHIRTemplate.Encounter Extends Resource
+{
+
+Parameter ResourceType = "Encounter";
+
+Parameter ClassSystem = "http://terminology.hl7.org/CodeSystem/v3-ActCode";
+
+/// 入院管理番号の名前空間の指定に使う。
+Parameter IdentifierSystem = "http://jpfhir.jp/fhir/Common/CodeSystem/resourceInstance-identifier";
+
+Parameter ClassHistorClassSystem = "http://terminology.hl7.org/CodeSystem/v3-ActCode";
+
+/// 入院はIMP、外来はAMB、退院時サマリーはIMPらしい
+Parameter ClassHistoryClassCode = "IMP,AMB";
+
+Parameter ClassHistoryClassDisplay = "入院,外来";
+
+/// 入院経路　例
+Parameter AdmitSourceSystem = "http://jpfhir.jp/fhir/Common/CodeSystem/admit-Source";
+
+/// AdmitSourceCodeの並びに対応する表示名がAdmitSourceDisplay
+Parameter AdmitSourceCode = "0,1,3,4,8,9";
+
+/// AdmitSourceDisplayの並びに対応するコードがAdmitSourceCode
+Parameter AdmitSourceDisplay = "院内の他病棟からの転棟,家庭からの入院,他の病院・診療所の病棟からの転院,介護施設・福祉施設に入所中,院内で出生,その他";
+
+/// 退院時転帰コード（コード表は暫定らしい）
+Parameter DischargeDispositionSystem = "http://jpfhir.jp/fhir/Common/CodeSystem/discharge-disposition";
+
+/// DischargeDispositionCodeの並びに対応する表示名がDischargeDispositionDisplay
+Parameter DischargeDispositionCode = "1,3,4,5,6,7,9";
+
+/// DischargeDispositionDisplayの並びに対応するコードがDischargeDispositionCode
+Parameter DischargeDispositionDisplay = "傷病が治癒・軽快,傷病（白血病、潰瘍性大腸炎、クローン病等）が寛解,傷病が不変,傷病が憎悪,傷病による死亡,その他（検査入院、正常分娩および人間ドックを含む）";
+
+Property Identifier As FHIRTemplate.Type.Identifier;
+
+Property ClassHistoryClass As FHIRTemplate.Type.Coding;
+
+Property ClassHistoryPeriod As FHIRTemplate.Type.Period;
+
+Property Period As FHIRTemplate.Type.Period;
+
+Property Length As FHIRTemplate.Type.Duration;
+
+/// reasonCode.coding.0.systemが記入できる場合コードで。MEDIS：標準病名マスター病名交換用コードが例にある（urn:oid:1.2.392.200119.4.101.6）
+Property ReasonCode As FHIRTemplate.Type.CodeableConcept;
+
+/// Conditionリソースのuuidを入れる
+Property DiagnosisCondition As %String;
+
+/// Organizationリソースのuuidを入れる
+Property HospitalizationOrigin As %String;
+
+Property AdmitSource As FHIRTemplate.Type.CodeableConcept;
+
+Property DischargeDisposition As FHIRTemplate.Type.CodeableConcept;
+
+/// 固定値にしたもの
+/// meta.profile/status/class以下/diagnosis.use.coding/diagnosis.rank
+XData Template [ MimeType = application/json ]
+{
+{
+    "resourceType": "#(..#ResourceType)#",
+    "meta": {
+        "profile": ["http://jpfhir.jp/fhir/eClinicalSummary/StructureDefinition/JP_Encounter_eClinicalSummary"]   
+    },
+    "identifier":["#(..Identifier(FHIRTemplate.Type.Identifier))#"],        
+    "status": "finished",
+    "class": {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code": "IMP",
+        "display":"入院"
+    },
+    "classHistory":[
+        {
+            "class":"#(..ClassHistoryClass(FHIRTemplate.Type.Coding))#",
+            "period":"#(..ClassHistoryPeriod(FHIRTemplate.Type.Period))#"
+        }
+    ],
+    "period":"#(..Period(FHIRTemplate.Type.Period))#",
+    "length":"#(..Length(FHIRTemplate.Type.Duration))#",
+    "reasonCode": ["#(..ReasonCode(FHIRTemplate.Type.CodeableConcept))#"],
+    "diagnosis":[
+        {
+            "condition":{
+                "reference":"urn:uuid:#(..DiagnosisCondition)#"
+            },
+            "use":{
+                "coding":[
+                    {
+                        "system": "http://terminology.hl7.org/CodeSystem/diagnosisrole",
+                        "code": "DD",
+                        "display": "退院時診断"                        
+                    }
+                ]
+            },
+            "rank":1
+        }
+    ],
+    "hospitalization":{
+        "origin":{
+            "reference":"urn:uuid:#(..HospitalizationOrigin)#"
+        },
+        "admitSource":"#(..AdmitSource(FHIRTemplate.Type.CodeableConcept))#",
+        "dischargeDisposition":"#(..DischargeDisposition(FHIRTemplate.Type.CodeableConcept))#"
+    }
+}
+}
+
+}

--- a/src/FHIRTemplate/MedicationRequest.cls
+++ b/src/FHIRTemplate/MedicationRequest.cls
@@ -1,0 +1,131 @@
+Class FHIRTemplate.MedicationRequest Extends FHIRTemplate.Resource
+{
+
+Parameter ResourceType = "MedicationRequest";
+
+Parameter TimingCodeSystem = "urn:oid:1.2.392.200250.2.2.20";
+
+Parameter RouteSystem = "http://jpfhir.jp/fhir/ePrescription/CodeSystem/route-codes";
+
+Parameter MethodSystem = "urn:oid:1.2.392.200250.2.2.20.30";
+
+Parameter DoseAndRateTypeSystem = "urn:oid:1.2.392.100495.20.2.22";
+
+Parameter DispenseRequestValueCodeableConceptSystem = "urn:oid:1.2.392.200250.2.2.30.10";
+
+Parameter DispenceRequestQuantitySystem = "urn:oid:1.2.392.200119.4.403.1";
+
+Property TextDiv As %String(MAXLEN = 10000);
+
+Property MedicationCodeableConcept As FHIRTemplate.Type.CodeableConcept;
+
+Property AuthoredOn As FHIRTemplate.Type.TimeStamp;
+
+/// Patient のUUID
+Property Patient As %String;
+
+Property DosageInstructionPeriod As FHIRTemplate.Type.PeriodNoEnd;
+
+Property DosageInstructionDuration As FHIRTemplate.Type.Duration;
+
+/// YYYY-MM-DD
+Property TimingEvent As %String;
+
+Property TimingRepetDuration As FHIRTemplate.Type.Duration;
+
+Property TimingCode As FHIRTemplate.Type.CodeableConcept;
+
+Property Route As FHIRTemplate.Type.CodeableConcept;
+
+Property Method As FHIRTemplate.Type.CodeableConcept;
+
+Property DoseAndRateType As FHIRTemplate.Type.CodeableConcept;
+
+Property DoseQuantity As FHIRTemplate.Type.SimpleQuantity;
+
+Property RateRatio As FHIRTemplate.Type.Quantity;
+
+Property Denominator As FHIRTemplate.Type.Quantity;
+
+Property DispenseRequestValueCodeableConcept As FHIRTemplate.Type.CodeableConcept;
+
+Property DispenseRequestQuantity As FHIRTemplate.Type.SimpleQuantity;
+
+Property ExpectedSupplyDuration As FHIRTemplate.Type.Duration;
+
+XData Template [ MimeType = application/json ]
+{
+{
+    "resourceType":"#(..#ResourceType)#",
+    "meta":{
+        "profile":["http://jpfhir.jp/fhir/ePrescription/StructureDefinition/JP_MedicationRequest_ePrescription"]
+    },
+    "text":{
+        "status":"generated",
+        "div":"#(..TextDiv)#"
+    },
+    "identifier":[
+        {
+            "system":"urn:oid:1.2.392.100495.20.3.81",
+            "value":"1"
+        },
+        {
+            "system":"urn:oid:1.2.392.100495.20.3.82",
+            "value":"1"
+        }
+    ],
+    "status":"completed",
+    "intent":"order",
+    "medicationCodeableConcept":"#(..MedicationCodeableConcept(FHIRTemplate.Type.CodeableConcept))#",
+    "subject":{
+        "reference":"urn:uuid:#(..Patient)#"
+    },
+    "authoredOn":"#(..AuthoredOn)#",
+    "dosageInstruction": [
+        {
+        "extension": [
+            {
+                "url":"http://jpfhir.jp/fhir/core/StructureDefinition/JP_MedicationRequest_DosageInstruction_PeriodOfUse",
+                "valuePeriod": "#(..DosageInstructionPeriod(FHIRTemplate.Type.PeriodNoEnd))#"
+            },
+            {
+                "url":"http://jpfhir.jp/fhir/core/StructureDefinition/JP_MedicationRequest_DosageInstruction_UsageDuration",
+                "valueDuration":"#(..DosageInstructionDuration(FHIRTemplate.Type.Duration))#"
+            }
+        ],
+        "text": "内服・経口・１日２回朝夕食後 １回２錠 7日分",
+        "timing": {
+            "event":["#(..TimingEvent)#"],
+            "repeat":{
+                "boundsDuration":"#(..TimingRepetDuration(FHIRTemplate.Type.Duration))#"
+            },
+            "code": "#(..TimingCode(FHIRTemplate.Type.CodeableConcept))#"
+        },
+        "route": "#(..Route(FHIRTemplate.Type.CodeableConcept))#",
+        "method":"#(..Method(FHIRTemplate.Type.CodeableConcept))#",
+        "doseAndRate": [
+            {
+                "type":"#(..DoseAndRateType(FHIRTemplate.Type.CodeableConcept))#",
+                "doseQuantity": "#(..DoseQuantity(FHIRTemplate.Type.SimpleQuantity))#",
+                "rateRatio": {
+                    "numerator":"#(..RateRatio(FHIRTemplate.Type.Quantity))#",
+                    "denominator": "#(..Denominator(FHIRTemplate.Type.Quantity))#"
+                }        
+            }
+        ]
+        }
+    ],
+    "dispenseRequest":{
+        "extension":[
+            {
+                "url":"http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DispenseRequest_InstructionForDispense",
+                "valueCodeableConcept":"#(..DispenseRequestValueCodeableConcept(FHIRTemplate.Type.CodeableConcept))#"
+            }
+        ],
+        "quantity":"#(..DispenseRequestQuantity(FHIRTemplate.Type.SimpleQuantity))#",
+        "expectedSupplyDuration": "#(..ExpectedSupplyDuration(FHIRTemplate.Type.Duration))#"            
+    }
+}
+}
+
+}

--- a/src/FHIRTemplate/Organization.cls
+++ b/src/FHIRTemplate/Organization.cls
@@ -1,0 +1,103 @@
+/// DischargeSummaryの文書作成医療機関情報の仕様で作成
+Class FHIRTemplate.Organization Extends Resource
+{
+
+Parameter ResourceType = "Organization";
+
+Property TextDiv As %String(MAXLEN = 10000);
+
+/// Extentionのidentifier.valueIdentifier.value
+Property PrefNum As %Integer;
+
+/// 点数コード　1:医科,3:歯科
+Property TensuCode As %Integer(VALUELIST = ",1,3");
+
+/// 保険医療機関番号7桁
+Property HokenNum7 As %Integer(MAXVAL = 7, MINVAL = 7);
+
+/// 保険医療機関番号10桁
+Property HokenNum10 As %Integer(MAXVAL = 10, MINVAL = 10);
+
+/// 医療機関名称
+Property HospitalName As %String(MAXLEN = 100);
+
+/// 医療機関電話番号
+Property Phone As %String;
+
+/// 医療機関住所文字列
+Property AddressText As %String(MAXLEN = 100);
+
+/// 医療機関郵便番号
+Property AddressZip As %String;
+
+/// 固定値
+/// meta.profile/extension/
+XData Template [ MimeType = application/json ]
+{
+{
+    "resourceType": "#(..#ResourceType)#",
+    "meta": {
+        "profile": ["http://jpfhir.jp/fhir/eClinicalSummary/StructureDefinition/JP_Organization_eClinicalSummary_issuer"]
+    },
+    "text":{
+        "status":"generated",
+        "div":"#(..TextDiv)#"
+    },
+    "extension":[
+        {
+            "url":"http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Organization_PrefectureNo",
+            "valueIdentifier":{
+                "system":"urn:oid:1.2.392.100495.20.3.21",
+                "value":"#(..PrefNum)#"
+            }
+        },
+        {
+            "url":"http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Organization_InsuranceOrganizationCategory",
+            "valueIdentifier":{
+                "system":"urn:oid:1.2.392.100495.20.3.22",
+                "value":"#(..TensuCode)#"
+            }            
+        },
+        {
+            "url":"http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Organization_InsuranceOrganizationNo",
+            "valueIdentifier":{
+                "system":"urn:oid:1.2.392.100495.20.3.23",
+                "value":"#(..HokenNum7)#"
+            }            
+        }
+    ],
+    "identifier": [
+        {
+            "system": "http://jpfhir.jp/fhir/Common/CodeSystem/insurance-medical-nstitution-no",
+            "value":"#(..HokenNum10)#"
+        }
+    ],
+    "type": [
+        {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                    "code": "prov",
+                    "display": "#(..HospitalName)#"
+                }
+            ]
+        }
+    ],
+    "name": "#(..HospitalName)#",
+    "telecom": [
+        {
+            "system": "phone",
+            "value": "#(..Phone)#"
+        }
+    ],
+    "address": [
+        {
+            "text":"#(..AddressText)#",
+            "postalCode": "#(..AddressZip)#",
+            "country": "JP"
+        }
+    ]
+}
+}
+
+}

--- a/src/FHIRTemplate/Practitioner.cls
+++ b/src/FHIRTemplate/Practitioner.cls
@@ -8,7 +8,9 @@ XData Template [ MimeType = application/json ]
 {
   "resourceType": "#(..#ResourceType)#",
   "meta": {
-    "profile": "#(..#Profile)#"
+    "profile": [
+      "#(..#Profile)#"
+    ]
   },
   "name": [
     {

--- a/src/FHIRTemplate/Type/Age.cls
+++ b/src/FHIRTemplate/Type/Age.cls
@@ -1,0 +1,24 @@
+Class FHIRTemplate.Type.Age Extends JSONTemplate.Base
+{
+
+Parameter SYSTEM = "http://unitsofmeasure.org";
+
+Property value As %Integer;
+
+Property unit As %String;
+
+Property system As %String;
+
+Property code As %String(DISPLAYLIST = ",minutes,hours,days,weeks,months,years", VALUELIST = ",min,h,d,wk,mo,a");
+
+XData Template [ MimeType = application/json ]
+{
+{
+        "value":"#(..value)#",
+        "unit": "#(..unit)#",
+        "system":"#(..#SYSTEM)#",
+        "code": "#(..code)#"
+}
+}
+
+}

--- a/src/FHIRTemplate/Type/CodeableConcept.cls
+++ b/src/FHIRTemplate/Type/CodeableConcept.cls
@@ -1,5 +1,5 @@
 /// CodableConcept
-Class FHIRTemplate.CodableConcept Extends JSONTemplate.Base
+Class FHIRTemplate.Type.CodeableConcept Extends JSONTemplate.Base
 {
 
 /// JSON出力する際のテンプレート

--- a/src/FHIRTemplate/Type/Coding.cls
+++ b/src/FHIRTemplate/Type/Coding.cls
@@ -1,0 +1,23 @@
+Class FHIRTemplate.Type.Coding Extends JSONTemplate.Base
+{
+
+XData Template [ MimeType = application/json ]
+{
+{
+        "system":"#(..system)#",
+        "code": "#(..code)#",
+        "display":"#(..display)#"
+}
+}
+
+Property system As %String(MAXLEN = 1000);
+
+Property display As %String;
+
+Property code As %String;
+
+Property version As %String;
+
+Property userSelected As %Boolean;
+
+}

--- a/src/FHIRTemplate/Type/Duration.cls
+++ b/src/FHIRTemplate/Type/Duration.cls
@@ -1,0 +1,24 @@
+Class FHIRTemplate.Type.Duration Extends JSONTemplate.Base
+{
+
+Parameter SYSTEM = "http://unitsofmeasure.org";
+
+Property value As %Integer;
+
+Property unit As %String;
+
+Property system As %String;
+
+Property code As %String;
+
+XData Template [ MimeType = application/json ]
+{
+{
+        "value":"#(..value)#",
+        "unit": "#(..unit)#",
+        "system":"#(..#SYSTEM)#",
+        "code": "#(..code)#"
+}
+}
+
+}

--- a/src/FHIRTemplate/Type/Identifier.cls
+++ b/src/FHIRTemplate/Type/Identifier.cls
@@ -1,0 +1,17 @@
+Class FHIRTemplate.Type.Identifier Extends JSONTemplate.Base
+{
+
+Property system As %String(MAXLEN = 1000);
+
+Property value As %String;
+
+/// JSON出力する際のテンプレート
+XData Template [ MimeType = application/json ]
+{
+{
+        "system":"#(..system)#",
+        "value":"#(..value)#"
+    }
+}
+
+}

--- a/src/FHIRTemplate/Type/Period.cls
+++ b/src/FHIRTemplate/Type/Period.cls
@@ -1,0 +1,16 @@
+Class FHIRTemplate.Type.Period Extends JSONTemplate.Base
+{
+
+Property start As %String;
+
+Property end As %String;
+
+XData Template [ MimeType = application/json ]
+{
+{
+        "start":"#(..start)#",
+        "end": "#(..end)#"
+}
+}
+
+}

--- a/src/FHIRTemplate/Type/PeriodNoEnd.cls
+++ b/src/FHIRTemplate/Type/PeriodNoEnd.cls
@@ -1,0 +1,15 @@
+Class FHIRTemplate.Type.PeriodNoEnd Extends JSONTemplate.Base
+{
+
+Property start As %String;
+
+Property end As %String;
+
+XData Template [ MimeType = application/json ]
+{
+{
+        "start":"#(..start)#"
+}
+}
+
+}

--- a/src/FHIRTemplate/Type/Quantity.cls
+++ b/src/FHIRTemplate/Type/Quantity.cls
@@ -1,0 +1,26 @@
+Class FHIRTemplate.Type.Quantity Extends JSONTemplate.Base
+{
+
+Parameter SYSTEM = "http://unitsofmeasure.org";
+
+Property value As %Integer;
+
+Property comparator As %String;
+
+Property unit As %String;
+
+Property system As %String;
+
+Property code As %String;
+
+XData Template [ MimeType = application/json ]
+{
+{
+        "value":"#(..value)#",
+        "unit": "#(..unit)#",
+        "system":"#(..#SYSTEM)#",
+        "code": "#(..code)#"
+}
+}
+
+}

--- a/src/FHIRTemplate/Type/SimpleQuantity.cls
+++ b/src/FHIRTemplate/Type/SimpleQuantity.cls
@@ -1,0 +1,22 @@
+Class FHIRTemplate.Type.SimpleQuantity Extends JSONTemplate.Base
+{
+
+Property value As %Integer;
+
+Property unit As %String;
+
+Property system As %String;
+
+Property code As %String;
+
+XData Template [ MimeType = application/json ]
+{
+{
+        "value":"#(..value)#",
+        "unit": "#(..unit)#",
+        "system":"#(..system)#",
+        "code": "#(..code)#"
+}
+}
+
+}

--- a/src/FHIRTemplate/Type/TimeStamp.CLS
+++ b/src/FHIRTemplate/Type/TimeStamp.CLS
@@ -1,4 +1,4 @@
-Class FHIRTemplate.TimeStamp Extends %DataType [ ClientDataType = TIMESTAMP, OdbcType = TIMESTAMP, SqlCategory = TIMESTAMP ]
+Class FHIRTemplate.Type.TimeStamp Extends %DataType [ ClientDataType = TIMESTAMP, OdbcType = TIMESTAMP, SqlCategory = TIMESTAMP ]
 {
 
 Parameter FORMAT = 1;
@@ -6,7 +6,7 @@ Parameter FORMAT = 1;
 ClassMethod LogicalToDisplay(%val) As %String [ CodeMode = generator, ServerOnly = 1 ]
 {
 	If ($$$getClassType(%class)=$$$cCLASSCLASSTYPEDATATYPE) || $$$comMemberKeyGet(%class,$$$cCLASSparameter,"XMLENABLED",$$$cPARAMdefault) || $$$comMemberKeyGet(%class,$$$cCLASSparameter,"%JSONENABLED",$$$cPARAMdefault) {
-        $$$GENERATE(" quit $translate($zdatetime(%val,3),"" "",""T"")_""+""_($ztimezone\60*100+($ztimezone#60)*(-1))")
+        $$$GENERATE(" quit $translate($zdatetime(%val,3),"" "",""T"")_"".""_($ztimezone\60*100+($ztimezone#60)*(-1))_""Z""")
     }
 }
 

--- a/src/FHIRTest/DischargeSummaryTest.cls
+++ b/src/FHIRTest/DischargeSummaryTest.cls
@@ -1,0 +1,381 @@
+Class FHIRTest.DischargeSummaryTest
+{
+
+/// 各リソース生成時にResourceId採番される
+ClassMethod Test1()
+{
+    set bundle=##class(FHIRTemplate.BundleDischargeSummary).%New()
+    set bundle.TimeStamp=$horolog
+
+    // Patient リソース
+    set patient=..Patient()
+
+    //Encounterリソース
+    set encounter=..Encounter()
+
+    //Organizationリソース
+    set organization=..Organization()    
+
+    //Practitionerリソース
+    set practitioner=..Practitioner()
+
+    //Conditionリソース
+    set condition=..Condition(patient)
+
+    //CarePlanリソース
+    set careplan=..CarePlan()
+
+    //MedicationRequestリソース
+    set medicationrequest=..MedicationRequest()
+
+    //AllergyIntoleranceリソース
+    set allergyintolerance=..AllergyIntolerance()
+
+    /*　リファレンスを設定する */ 
+
+    /*
+    Encounter referenceの設定
+        Condision: DiagnosisCondition
+        Organization: HospitalizationOrigin
+    */
+    set encounter.DiagnosisCondition=condition.ResourceId
+    set encounter.HospitalizationOrigin=organization.ResourceId
+    
+    /*
+    Condition reference の設定
+        subject: Patientリソース
+        encounter: Encounterリソース
+        evidence: Encounterリソース
+    */
+    set condition.Patient=patient.ResourceId
+    set condition.Encounter=encounter.ResourceId
+    set condition.EvidenceDetail=encounter.ResourceId
+
+    /*
+    CarePlan referenceの設定
+        subject: Patientリソース
+        encounter: Encounterリソース
+        author: Practitionerリソース
+    */
+    set careplan.Patient=patient.ResourceId
+    set careplan.Encounter=encounter.ResourceId
+    set careplan.Practitioner=practitioner.ResourceId
+
+    /*
+    MedicationRequest reference の設定
+        subject: Patient リソース
+    */
+    set medicationrequest.Patient=patient.ResourceId
+
+    /*
+    AllertyIntolerance referenceの設定
+    */
+    set allergyintolerance.Patient=patient.ResourceId
+    set allergyintolerance.Encounter=encounter.ResourceId
+
+    //Compositionリソース
+    set composition=..Composition()
+    /*
+    Composition reference の設定
+        subject: Patientリソース
+        encounter: Encounterリソース
+        author : Practitionerリソース
+        author : Organizationリソース
+        残り構造情報のリソースたち
+    */
+    set composition.Patient=patient.ResourceId
+    set composition.Encounter=encounter.ResourceId
+    set composition.Practitioner=practitioner.ResourceId
+    set composition.Organization=organization.ResourceId
+    set composition.Condition=condition.ResourceId
+    set composition.CarePlan=careplan.ResourceId
+    set composition.MedicationRequest=medicationrequest.ResourceId
+    set composition.AllergyIntolerance=allergyintolerance.ResourceId
+
+    // bundleへの追加
+    set bundle.Composition=composition
+    set bundle.Patient=patient
+    set bundle.Practitioner=practitioner
+    set bundle.Organization=organization
+    set bundle.Encounter=encounter
+    set bundle.Condition=condition
+    set bundle.CarePlan=careplan
+    set bundle.MedicationRequest=medicationrequest
+    set bundle.AllergyIntolerance=allergyintolerance
+
+    set bundle.When=$ZDATETIMEH("2021-08-21",3)
+    set bundle.PractitionerResourceId=practitioner.ResourceId
+
+    set ret=bundle.OutputToFile("bundle.json")
+    if $$$ISOK(ret) {
+        use 0 write "正常終了",!
+    }else {
+        use 0 write "エラー発生",!
+        do $SYSTEM.OBJ.DisplayError(ret)
+    }
+}
+
+ClassMethod Patient() As FHIRTemplate.Patient
+{
+    set patient=##class(FHIRTemplate.Patient).%New()
+    set patient.PostalCode="185-0012"
+    set patient.Address="国分寺市本町3-7-20-102"
+    set patient.DOB="1976-02-25"
+    set patient.Gender=2
+    set patient.PatientId="P0101"
+    set patient.LastName="飯島"
+    set patient.FirstName="美穂子"
+    set patient.LastNameKana="イイジマ"
+    set patient.FirstNameKana="ミホコ"
+    set patient.Phone="080-5644-6480"
+    return patient
+}
+
+ClassMethod Encounter() As FHIRTemplate.Encounter
+{
+    set encounter=##class(FHIRTemplate.Encounter).%New()
+    //Encounter.Identifier
+    set identifier=##class(FHIRTemplate.Type.Identifier).%New()
+    set identifier.system=encounter.#IdentifierSystem
+    set identifier.value="1234567890-1234-12345678"
+    set encounter.Identifier=identifier
+    //Encounter.classHistory.class
+    set classhistory=##class(FHIRTemplate.Type.Coding).%New()
+    set classhistory.system=encounter.#ClassHistorClassSystem
+    set classhistory.code=$piece(encounter.#ClassHistoryClassCode,",",2)
+    set classhistory.display=$piece(encounter.#ClassHistoryClassDisplay,",",2)
+    set encounter.ClassHistoryClass=classhistory
+    //Encounter.classHisotry.period
+    set classhistoryperiod=##class(FHIRTemplate.Type.Period).%New()
+    set classhistoryperiod.start="2020-08-21"
+    set classhistoryperiod.end="2020-08-21"
+    set encounter.ClassHistoryPeriod=classhistoryperiod
+    //Encounter.period
+    set period=##class(FHIRTemplate.Type.Period).%New()
+    set period.start="2020-09-01"
+    set period.end="2020-09-18"
+    set encounter.Period=period
+    //Encounter.Length
+    set length=##class(FHIRTemplate.Type.Duration).%New()
+    set length.value=7
+    set length.unit="日"
+    set length.code="d"
+    set encounter.Length=length
+    //Encounter.reasonCode
+    set reasoncode=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set reasoncode.system="urn:oid:1.2.392.200119.4.101.6"
+    set reasoncode.code="B0EF"
+    set reasoncode.display="持続腹痛"
+    set encounter.ReasonCode=reasoncode
+    //Encounter.hospitalization.admitSource
+    set admitsource=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set admitsource.system=encounter.#AdmitSourceSystem
+    set admitsource.code=$piece(encounter.#AdmitSourceCode,",",2)
+    set admitsource.display=$piece(encounter.#AdmitSourceDisplay,",",2)
+    set encounter.AdmitSource=admitsource
+    //Encounter.hospitalizationdischargeDisposition
+    set disposition=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set disposition.system=encounter.#DischargeDispositionSystem
+    set disposition.code=$piece(encounter.#DischargeDispositionCode,",",1)
+    set disposition.display=$piece(encounter.#DischargeDispositionDisplay,",",1)
+    set encounter.DischargeDisposition=disposition
+    return encounter
+}
+
+ClassMethod Organization() As FHIRTemplate.Organization
+{
+    set organization=##class(FHIRTemplate.Organization).%New()
+    set organization.TextDiv="<div xmlns='http://www.w3.org/1999/xhtml'>テスト組織です</div>"
+    set organization.PrefNum=13 //都道府県番号らしい
+    set organization.TensuCode=1
+    set organization.HokenNum7=1234567
+    set organization.HokenNum10=1234567890
+    set organization.HospitalName="厚生労働省第一病院"
+    set organization.Phone="0120-012-0123"
+    set organization.AddressText="神奈川県横浜市港区１－２－３"
+    set organization.AddressZip="111-2222"
+    return organization
+}
+
+ClassMethod Practitioner() As FHIRTemplate.Practitioner
+{
+    set practitioner=##class(FHIRTemplate.Practitioner).%New()
+    set practitioner.FirstName="花子"
+    set practitioner.LastName="神奈川"
+    set practitioner.FirstNameKana="ハナコ"
+    set practitioner.LastNameKana="カナガワ"
+    return practitioner
+}
+
+ClassMethod Condition(patient As FHIRTemplate.Patient) As FHIRTemplate.Condition
+{
+    set condition=##class(FHIRTemplate.Condition).%New()
+    set condition.TextDiv="<div xmlns='http://www.w3.org/1999/xhtml'>こんな状況でした</div>"
+    set condition.PatientStatusValue="1311234567-2020-00123456"
+    set clinicalstatus=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set clinicalstatus.system=condition.#ClinicalStatusSystem
+    set clinicalstatus.code=$piece(condition.#ClinicalStatusCode,",",1)  //active
+    set clinicalstatus.display=$piece(condition.#ClinicalStatusDisplay,",",1)  //このディスプレイでいいのか不明
+    set condition.ClinicalStatus=clinicalstatus
+    set verificationStatus=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set verificationStatus.system=condition.#VerificationStatusSystem
+    set verificationStatus.code=$piece(condition.#VerificationStatusCode,",",2) //provisional
+    set verificationStatus.display=$piece(condition.#VerificationStatusDisplay,",",2) //このディスプレイでいいのか不明
+    set code=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set code.system="urn:oid:1.2.392.200119.4.101.6"
+    set code.code="B0EF"
+    set code.display="持続腹痛"
+    set condition.Code=code
+    set bodysite=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set bodysite.system="urn:oid:1.2.392.200119.4.201.5"
+    set bodysite.code="1244"
+    set bodysite.display="腹部"
+    set condition.BodySite=bodysite
+    set condition.PatientDisplayName=patient.LastName_patient.FirstName
+    set age=##class(FHIRTemplate.Type.Age).%New()
+    set age.value=10
+    set age.unit="歳"
+    set age.code="a"
+    set condition.Age=age
+    set condition.RecordedDate="2020-09-01"
+    return condition
+}
+
+ClassMethod Composition() As FHIRTemplate.CompositionDischargeSummary
+{
+    set composition=##class(FHIRTemplate.CompositionDischargeSummary).%New()
+    set composition.DocVersionNum="1.0"
+    set composition.IdentifierValue="1311234567-2020-00123456"
+    set composition.CreationDate=$ZDATETIMEH("2020-09-18",3)
+    return composition
+}
+
+ClassMethod CarePlan() As FHIRTemplate.CarePlan
+{
+    set careplan=##class(FHIRTemplate.CarePlan).%New()
+    set careplan.TextDiv="<div xmlns='http://www.w3.org/1999/xhtml'>こんな計画です</div>"
+    set careplan.IdentifierValue="1311234567-2020-00123456"
+    set careplan.Status="active"
+    set careplan.Intent="plan"
+    set category=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set category.system=careplan.#CategorySystem
+    set category.code="736285004"
+    set category.display=careplan.#CategoryDisplay
+    set careplan.Category=category
+    set careplan.Description="2020/9/30に循環器内科Dr笹田外来受診、その後○×クリニックへ逆紹介の予定"
+    //set period=##class(FHIRTemplate.Type.Period).%New()
+    //set period.start="2020-09-18T15:25:16+09:00"
+    //set careplan.Period=period
+    set careplan.CreationTime=$ZDATETIMEH("2020-09-15",3)
+    return careplan
+}
+
+ClassMethod MedicationRequest() As FHIRTemplate.MedicationRequest
+{
+    set medicationrequest=##class(FHIRTemplate.MedicationRequest).%New()
+    set medicationrequest.TextDiv="<div xmlns='http://www.w3.org/1999/xhtml'>退院後に飲んでもらうお薬です</div>"
+    set medicationrequest.AuthoredOn=$ZDATETIMEH("2020-09-15",3)
+    set MedicationCodeableConcept=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    //Hot9のコードを入れる
+    set MedicationCodeableConcept.system="urn:oid:1.2.392.200119.4.403.1"
+    set MedicationCodeableConcept.code="103831601"
+    set MedicationCodeableConcept.display="カルボシステイン錠２５０ｍｇ"
+    set medicationrequest.MedicationCodeableConcept=MedicationCodeableConcept
+    set DosageInstructionPeriod=##class(FHIRTemplate.Type.PeriodNoEnd).%New()
+    set DosageInstructionPeriod.start="2020-09-21"
+    set medicationrequest.DosageInstructionPeriod=DosageInstructionPeriod
+    set DosageInstructionDuration=##class(FHIRTemplate.Type.Duration).%New()
+    set DosageInstructionDuration.value=7
+    set DosageInstructionDuration.unit="日"
+    set DosageInstructionDuration.code="d"
+    set medicationrequest.DosageInstructionDuration=DosageInstructionDuration
+    set medicationrequest.TimingEvent="2020-09-15"
+    set TimingRepetDuration=##class(FHIRTemplate.Type.Duration).%New()
+    set TimingRepetDuration.value=7
+    set TimingRepetDuration.unit="日"
+    set TimingRepetDuration.code="d"
+    set medicationrequest.TimingRepetDuration=TimingRepetDuration
+    set TimingCode=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set TimingCode.system=medicationrequest.#TimingCodeSystem
+    set TimingCode.code="1012040400000000"
+    set TimingCode.display="内服・経口・１日２回朝夕食後"
+    set medicationrequest.TimingCode=TimingCode
+    set Route=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set Route.system=medicationrequest.#RouteSystem
+    set Route.code="PO"
+    set Route.display="経口"
+    set medicationrequest.Route=Route
+    set method=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set method.system=medicationrequest.#MethodSystem
+    set method.code=1
+    set method.display="内服"
+    set DoseAndRateType=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set DoseAndRateType.system=medicationrequest.#DoseAndRateTypeSystem
+    set DoseAndRateType.code="1"
+    set DoseAndRateType.display="製剤量"
+    set medicationrequest.DoseAndRateType=DoseAndRateType
+    set DoseQuantity=##class(FHIRTemplate.Type.SimpleQuantity).%New()
+    set DoseQuantity.value=2
+    set DoseQuantity.unit="錠"
+    set DoseQuantity.system="urn:oid:1.2.392.100495.20.2.101"
+    set DoseQuantity.code="TAB"
+    set medicationrequest.DoseQuantity=DoseQuantity
+    set RateRatio=##class(FHIRTemplate.Type.Quantity).%New()
+    set RateRatio.value=4
+    set RateRatio.unit="錠"
+    set RateRatio.system="urn:oid:1.2.392.100495.20.2.101"
+    set RateRatio.code="TAB"
+    set medicationrequest.RateRatio=RateRatio
+    set Denominator=##class(FHIRTemplate.Type.Quantity).%New()
+    set Denominator.value=1
+    set Denominator.unit="日"
+    set Denominator.system="http://unitsofmeasure.org"
+    set Denominator.code="d"
+    set medicationrequest.Denominator=Denominator
+    set DispenseRequestValueCodeableConcept=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set DispenseRequestValueCodeableConcept.system=medicationrequest.#DispenseRequestValueCodeableConceptSystem
+    set DispenseRequestValueCodeableConcept.code="c"
+    set DispenseRequestValueCodeableConcept.display="粉砕指示"
+    set medicationrequest.DispenseRequestValueCodeableConcept=DispenseRequestValueCodeableConcept
+    set DispenseRequestQuantity=##class(FHIRTemplate.Type.SimpleQuantity).%New()
+    set DispenseRequestQuantity.value=28
+    set DispenseRequestQuantity.unit="錠"
+    set DispenseRequestQuantity.system=medicationrequest.#DispenceRequestQuantitySystem
+    set DispenseRequestQuantity.code="TAB"
+    set medicationrequest.DispenseRequestQuantity=DispenseRequestQuantity
+    set ExpectedSupplyDuration=##class(FHIRTemplate.Type.Duration).%New()
+    set ExpectedSupplyDuration.value=7
+    set ExpectedSupplyDuration.unit="日"
+    set ExpectedSupplyDuration.system="http://unitsofmeasure.org"
+    set ExpectedSupplyDuration.code="d"
+    set medicationrequest.ExpectedSupplyDuration=ExpectedSupplyDuration
+    return medicationrequest
+}
+
+ClassMethod AllergyIntolerance() As FHIRTemplate.AllergyIntolerance
+{
+    set allergy=##class(FHIRTemplate.AllergyIntolerance).%New()
+    set allergy.TextDiv="<div xmlns='http://www.w3.org/1999/xhtml'>申告されたアレルギーです</div>"
+    set allergy.IdentifierValue="1311234567-2020-00123456"
+    set ClinicalStatus=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set ClinicalStatus.system="http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical"
+    set ClinicalStatus.code=$piece(allergy.#ClinicalStatusCode,",",1)
+    set ClinicalStatus.display=$piece(allergy.#ClinicalStatusDisplay,",",1)
+    set allergy.ClinicalStatus=ClinicalStatus
+    set VerificationStatus=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set VerificationStatus.system="http://terminology.hl7.org/CodeSystem/allergyintolerance-verification"
+    set VerificationStatus.code=$piece(allergy.#VerificationStatusCode,",",1)
+    set VerificationStatus.display=$piece(allergy.#VerificationStatusDisplay,",",1)
+    set allergy.VerificationStatus=VerificationStatus
+    set allergy.Type="allergy"
+    set allergy.Category="food"
+    set allergy.Criticality="high"
+    set Code=##class(FHIRTemplate.Type.CodeableConcept).%New()
+    set Code.system="http://jpfhir.jp/fhir/AllergyIntolerance/CodeSystem/allergy-substance"
+    set Code.code="J7F7111190"
+    set Code.display="さば類"
+    set allergy.Code=Code
+    return allergy
+}
+
+}


### PR DESCRIPTION
- TimeStampとCodeableConceptをTypeパッケージ以下に移動しました。
- DischargeSummaryのPDF（https://std.jpfhir.jp/stddoc/eDischargeSummaryFHIR_v1x.pdf　P9～）で必須と書いているリソースのクラスを追加してみました（AllergyIntolerance/CarePlan/Condition/DocumentReference/Condition/Encounter/MedicationRequest/Organization）
- DischargeSummary用BundleにBundleDischargeSummaryを追加しました。
- DischargeSummary用CompositionにComposisionDischargeSummaryを追加しました。
- テストクラス1つ追加しました（FHIRTest.DischargeSummaryTest） 
- データタイプのDurationとQuantityのvalueプロパティと、Encounter.diagnosis.rank が %Integer なのですが、Template経由の出力時 "" 二重引用符が付くため、IRISのFHIR用検証でエラーになりました。
例：ERROR <HSFHIRErr>WrongJsonType: Property 'value' of Type 'Duration' is type string but must be number